### PR TITLE
Implement create bucketlist

### DIFF
--- a/app/controllers/api/bucketlists_controller.rb
+++ b/app/controllers/api/bucketlists_controller.rb
@@ -5,6 +5,16 @@ module Api
       render json: @bucketlists
     end
 
+    def create
+      @bucketlist = Bucketlist.new(bucketlist_params)
+
+      if @bucketlist.save
+        render json: @bucketlist, status: 201 # created
+      else
+        render json: @bucketlist.errors.full_messages, status: 400
+      end
+    end
+
     def show
       @bucketlist = Bucketlist.find(params[:id])
       render json: @bucketlist
@@ -18,6 +28,12 @@ module Api
       render json: { message: "Bucketlist deleted successfully" }, status: 200
     rescue
       render json: { error: "No such bucketlist was found" }, status: 404
+    end
+
+    private
+
+    def bucketlist_params
+      params.permit(:name)
     end
   end
 end

--- a/spec/controllers/bucketlists_controller_spec.rb
+++ b/spec/controllers/bucketlists_controller_spec.rb
@@ -40,4 +40,18 @@ RSpec.describe Api::BucketlistsController, type: :controller do
       expect(response).to have_http_status(404)
     end
   end
+
+  describe "POST create" do
+    it "creates a new bucketlist instance on valid params" do
+      post :create, name: "Endless"
+      expect(Bucketlist.count).to eq(1)
+      expect(response).to have_http_status(201)
+    end
+
+    it "creates a new bucketlist instance on invalid params" do
+      post :create, name: ""
+      expect(Bucketlist.count).to eq(0)
+      expect(response).to have_http_status(400)
+    end
+  end
 end


### PR DESCRIPTION
Why?
When an API consumer makes a post request to the `/bucketlist` with the
parameters
A new instance of bucketlist should be created

How?
Created the `create` controller action
Write the cerate login
Write the test for the create controller method

Completing https://www.pivotaltracker.com/story/show/111771582
[finished #111771582]
