### PR TITLE
Fix Heroku Seeding Bug

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,10 +8,10 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-User.destroy_all
-Bucketlist.destroy_all
-Item.destroy_all
 Token.destroy_all
+Item.destroy_all
+Bucketlist.destroy_all
+User.destroy_all
 
 2.times do |i|
   user = User.create(


### PR DESCRIPTION
Why?
When I run 'heroku run rake db:seed'
I get foreign key constraint error
Because the seed file is trying to clear the bucketlist table without
clearing the Items table that depend on them

How?
Make the delete_all call of the Item model to come first, then Bucketlist
and finally User

Completing https://www.pivotaltracker.com/story/show/111833041
[finished #111833041]
