### PR TITLE
Implement Multiple Versioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "active_model_serializers"
 gem "faker"
 gem "bcrypt"
 gem "jwt"
+gem "versionist"
 
 group :development do
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,11 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    versionist (1.4.1)
+      activesupport (>= 3)
+      railties (>= 3)
+      yard (~> 0.7)
+    yard (0.8.7.6)
 
 PLATFORMS
   ruby
@@ -180,6 +185,7 @@ DEPENDENCIES
   simplecov
   spring
   sqlite3
+  versionist
 
 BUNDLED WITH
    1.11.2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Every operations are are secured to a registered user's access. This mean that e
 
 This API uses JWT authentication to validate a request. That is to say that every request to the API is sent with an authentication token which is gotten when a user logs in for the first time.
 
-For full documentation, and usage examples, see https://ebucketlist-staging.herokuapp.com/
+For full documentation, and usage examples, see http://ebucketlist-staging.herokuapp.com/
 
 ## Available endpoints.
 
@@ -26,6 +26,21 @@ For full documentation, and usage examples, see https://ebucketlist-staging.hero
 | DELETE /bucketlists/:id/items/:item_id  | Delete an item in a bucket lists     |
 | POST /users/                            | Create a new user                    |
 
+## Versioning
+Changes and upgrades are made from time to time in this API. So that a consumer's code does not break, the major changes are made as a different version. We have provided three ways of specifying the requested version, these are listed below:
+
+### By specifying the version in the url path
+        GET /api/v1/<some-endpoint>
+
+### By passing the `Accept` header stating the version in your request
+```ruby
+{'Accept' => 'application/vnd.mycompany.com; version=1'}
+```
+
+### By passing the `version` parameter to the url
+        GET /api/<some-endpoint>?version=v1
+
+Also, if the version is not passed in anyway, the requests defaults to version 1.
 
 ## Limitations
 The API only responds with json, and does not yet have support for xml and other response types.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,15 @@
 Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
-    namespace :v1 do
+    api_version(
+      module: "V1",
+      header: {
+        name: "Accept",
+        value: "application/vnd.ebucketlist.herokuapp.com; version=1"
+      },
+      path: { value: "v1" },
+      parameter: { name: "version", value: "v1" },
+      default: true
+    ) do
       resources :bucketlists, except: [:new, :edit] do
         resources :items, only: [:create, :update, :destroy]
       end

--- a/spec/requests/api/versioning_methods_spec.rb
+++ b/spec/requests/api/versioning_methods_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "API Versioning", type: :request do
+  include_context "before suite"
+
+  describe "GET /bucketlists" do
+    context "when version is specified on url path" do
+      it "returns items by the user with valid token provided" do
+        token = api_token
+        get "/api/v1/bucketlists", nil, HTTP_AUTHORIZATION: token
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when version specified in the 'Accept' header" do
+      it "returns items by the user with valid token provided" do
+        token = api_token
+        get(
+          "/api/bucketlists",
+          nil,
+          HTTP_AUTHORIZATION: token,
+          Accept: "application/vnd.ebucketlist.herokuapp.com; version=1"
+        )
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when version is passed as a parameter in the url" do
+      it "returns items by the user with valid token provided" do
+        token = api_token
+        get "/api/bucketlists?version=v1", nil, HTTP_AUTHORIZATION: token
+
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Why?
API consumer should be able to specify the version of the API they want

How?
Add the `versionist` gem to the Gemfile and bundle install
Use `versionist`'s `api_version` method to handle the versioning methods
Write tests to confirm the multiple versioning methods

Completing https://www.pivotaltracker.com/story/show/112504967
[finished #112504967]
