### PR TITLE
Enable Cross-Origin-Resource-Sharing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,10 @@ module BucketlistApi
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.action_dispatch.default_headers = {
+      'Access-Control-Allow-Origin' => '*',
+      'Access-Control-Request-Method' => %w{GET POST PUT DELETE}.join(",")
+    }
   end
 end


### PR DESCRIPTION
enable Cross-Origin-Resource-Sharing by modifying the application.rb and setting it to accept from \* which means every origin.
